### PR TITLE
Adicionar componente de Typography

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watchAll"
+    "test": "jest --watchAll",
+    "coverage": "jest --coverage"
   },
   "dependencies": {
     "cookies-next": "^4.2.1",

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -26,7 +26,7 @@ export function Typography({
   className,
   variant = "h4",
   fontWeight,
-  colorText,
+  textColor,
   as,
   ...props
 }: TypographyProps) {
@@ -38,7 +38,7 @@ export function Typography({
     <Tag
       data-testid="typography-container"
       className={cn(
-        typographyVariants({ variant, fontWeight, colorText }),
+        typographyVariants({ variant, fontWeight, textColor }),
         className
       )}
       {...props}

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+import { VariantProps } from "class-variance-authority";
+import { ComponentProps, ReactNode } from "react";
+import { typographyVariants } from "./typography-variants";
+
+export interface TypographyGroupProps
+  extends VariantProps<typeof typographyVariants>,
+    ComponentProps<"span"> {
+  children: ReactNode;
+  className?: string;
+}
+
+export function Typography({
+  children,
+  className,
+  variant,
+  fontWeight,
+  ...props
+}: TypographyGroupProps) {
+  return (
+    <span
+      data-testid="typography-container"
+      className={cn(typographyVariants({ variant, fontWeight }), className)}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -36,6 +36,7 @@ export function Typography({
 
   return (
     <Tag
+      data-testid="typography-container"
       className={cn(
         typographyVariants({ variant, fontWeight, colorText }),
         className

--- a/src/components/typography/index.tsx
+++ b/src/components/typography/index.tsx
@@ -1,29 +1,48 @@
 import { cn } from "@/lib/utils";
-import { VariantProps } from "class-variance-authority";
-import { ComponentProps, ReactNode } from "react";
+import type { VariantProps } from "class-variance-authority";
+import type { ElementType, ReactNode } from "react";
 import { typographyVariants } from "./typography-variants";
 
-export interface TypographyGroupProps
-  extends VariantProps<typeof typographyVariants>,
-    ComponentProps<"span"> {
+export interface TypographyProps
+  extends VariantProps<typeof typographyVariants> {
   children: ReactNode;
   className?: string;
+  as?: ElementType;
 }
+
+const tags = {
+  h1: "h1",
+  h2: "h2",
+  h3: "h3",
+  h4: "h4",
+  h5: "h5",
+  h6: "h6",
+  body1: "p",
+  body2: "p",
+} as const;
 
 export function Typography({
   children,
   className,
-  variant,
+  variant = "h4",
   fontWeight,
+  colorText,
+  as,
   ...props
-}: TypographyGroupProps) {
+}: TypographyProps) {
+  const validVariant = variant ?? "h4";
+  const Tag: ElementType =
+    as || tags[validVariant as keyof typeof tags] || "span";
+
   return (
-    <span
-      data-testid="typography-container"
-      className={cn(typographyVariants({ variant, fontWeight }), className)}
+    <Tag
+      className={cn(
+        typographyVariants({ variant, fontWeight, colorText }),
+        className
+      )}
       {...props}
     >
       {children}
-    </span>
+    </Tag>
   );
 }

--- a/src/components/typography/typography-variants.ts
+++ b/src/components/typography/typography-variants.ts
@@ -1,0 +1,31 @@
+import { cva } from "class-variance-authority";
+
+export const typographyVariants = cva("text-foreground teleading-4", {
+  variants: {
+    variant: {
+      h1: "text-[64px]",
+      h2: "text-[44px]",
+      h3: "text-[36px]",
+      h4: "text-[28px]",
+      h5: "text-[24px]",
+      h6: "text-[20px]",
+      body1: "text-[18px]",
+      body2: "text-[16px]",
+    },
+    fontWeight: {
+      thin: "font-thin",
+      extralight: "font-extralight",
+      light: "font-light",
+      regular: "font-normal",
+      medium: "font-medium",
+      semibold: "font-semibold",
+      bold: "font-bold",
+      extrabold: "font-extrabold",
+      black: "font-black",
+    },
+  },
+  defaultVariants: {
+    variant: "h1",
+    fontWeight: "regular",
+  },
+});

--- a/src/components/typography/typography-variants.ts
+++ b/src/components/typography/typography-variants.ts
@@ -23,9 +23,16 @@ export const typographyVariants = cva("text-foreground teleading-4", {
       extrabold: "font-extrabold",
       black: "font-black",
     },
+    colorText: {
+      white: "text-[#ffffff]",
+      black: "text-[#000000]",
+      primary: "text-[#43A046]",
+      secondary: "text-[#263238]",
+    },
   },
   defaultVariants: {
-    variant: "h1",
+    variant: "h4",
     fontWeight: "regular",
+    colorText: "black",
   },
 });

--- a/src/components/typography/typography-variants.ts
+++ b/src/components/typography/typography-variants.ts
@@ -3,14 +3,14 @@ import { cva } from "class-variance-authority";
 export const typographyVariants = cva("text-foreground teleading-4", {
   variants: {
     variant: {
-      h1: "text-[64px]",
-      h2: "text-[44px]",
-      h3: "text-[36px]",
-      h4: "text-[28px]",
-      h5: "text-[24px]",
-      h6: "text-[20px]",
-      body1: "text-[18px]",
-      body2: "text-[16px]",
+      h1: "text-[4rem]",
+      h2: "text-[2.75rem]",
+      h3: "text-[2.25rem]",
+      h4: "text-[1.75rem]",
+      h5: "text-[1.5rem]",
+      h6: "text-[1.25rem]",
+      body1: "text-[1.12rem]",
+      body2: "text-[1rem]",
     },
     fontWeight: {
       thin: "font-thin",
@@ -23,7 +23,7 @@ export const typographyVariants = cva("text-foreground teleading-4", {
       extrabold: "font-extrabold",
       black: "font-black",
     },
-    colorText: {
+    textColor: {
       white: "text-[#ffffff]",
       black: "text-[#000000]",
       primary: "text-[#43A046]",
@@ -33,6 +33,6 @@ export const typographyVariants = cva("text-foreground teleading-4", {
   defaultVariants: {
     variant: "h4",
     fontWeight: "regular",
-    colorText: "black",
+    textColor: "black",
   },
 });

--- a/src/components/typography/typography.page.tsx
+++ b/src/components/typography/typography.page.tsx
@@ -1,10 +1,9 @@
 import { renderPageObjects } from "@/test-utils";
 import { screen } from "@testing-library/react";
 
-import { Typography, TypographyGroupProps } from ".";
+import { Typography, TypographyProps } from ".";
 
-export const initialProps: TypographyGroupProps = {
-  title: "Hello World",
+export const initialProps: TypographyProps = {
   children: "Hello World",
   variant: "h1",
   fontWeight: "bold",

--- a/src/components/typography/typography.page.tsx
+++ b/src/components/typography/typography.page.tsx
@@ -1,0 +1,28 @@
+import { renderPageObjects } from "@/test-utils";
+import { screen } from "@testing-library/react";
+
+import { Typography, TypographyGroupProps } from ".";
+
+export const initialProps: TypographyGroupProps = {
+  title: "Hello World",
+  children: "Hello World",
+  variant: "h1",
+  fontWeight: "bold",
+};
+
+const TYPOGRAPHY_CONTAINER_TEST_ID = "typography-container";
+
+export const TypographyPageObjects = () => {
+  const render = (props = initialProps) => {
+    return renderPageObjects({
+      component: <Typography {...props} />,
+    });
+  };
+
+  const getTypography = () => screen.getByTestId(TYPOGRAPHY_CONTAINER_TEST_ID);
+
+  return {
+    render,
+    getTypography,
+  };
+};

--- a/src/components/typography/typography.page.tsx
+++ b/src/components/typography/typography.page.tsx
@@ -6,7 +6,8 @@ import { Typography, TypographyProps } from ".";
 export const initialProps: TypographyProps = {
   children: "Hello World",
   variant: "h1",
-  fontWeight: "bold",
+  fontWeight: "regular",
+  textColor: "primary",
 };
 
 const TYPOGRAPHY_CONTAINER_TEST_ID = "typography-container";

--- a/src/components/typography/typography.test.tsx
+++ b/src/components/typography/typography.test.tsx
@@ -4,11 +4,7 @@ const pageObjects = TypographyPageObjects();
 
 describe("Typography component", () => {
   beforeEach(() => {
-    pageObjects.render({
-      children: "Hello World",
-      variant: "h1",
-      fontWeight: "regular",
-    });
+    pageObjects.render();
   });
 
   it("should render component Typography", () => {
@@ -20,12 +16,14 @@ describe("Typography component", () => {
   });
 
   it("should apply correct classes for variant and fontWeight", () => {
-    expect(pageObjects.getTypography()).toHaveClass("text-[64px] font-normal");
+    expect(pageObjects.getTypography()).toHaveClass(
+      "text-[4rem] font-normal text-[#43A046]"
+    );
   });
 
   it("should apply default variant and fontWeight if not provided", () => {
     const typographyElement = pageObjects.getTypography();
-    expect(typographyElement).not.toHaveClass("text-[28px]");
+    expect(typographyElement).not.toHaveClass("text-[1.75rem]");
     expect(typographyElement).not.toHaveClass("font-bold");
   });
 });

--- a/src/components/typography/typography.test.tsx
+++ b/src/components/typography/typography.test.tsx
@@ -1,0 +1,31 @@
+import { TypographyPageObjects } from "./typography.page";
+
+const pageObjects = TypographyPageObjects();
+
+describe("Typography component", () => {
+  beforeEach(() => {
+    pageObjects.render({
+      children: "Hello World",
+      variant: "h1",
+      fontWeight: "regular",
+    });
+  });
+
+  it("should render component Typography", () => {
+    expect(pageObjects.getTypography()).toBeInTheDocument();
+  });
+
+  it("must contain Hello World in the value of children", () => {
+    expect(pageObjects.getTypography()).toHaveTextContent("Hello World");
+  });
+
+  it("should apply correct classes for variant and fontWeight", () => {
+    expect(pageObjects.getTypography()).toHaveClass("text-[64px] font-normal");
+  });
+
+  it("should apply default variant and fontWeight if not provided", () => {
+    const typographyElement = pageObjects.getTypography();
+    expect(typographyElement).not.toHaveClass("text-[28px]");
+    expect(typographyElement).not.toHaveClass("font-bold");
+  });
+});


### PR DESCRIPTION
Exemplo de uso:
![typography](https://github.com/user-attachments/assets/0f3f6347-bbc8-46fa-954f-e0af2c0a2e18)

Evidencias:
https://github.com/user-attachments/assets/1f1d6833-4ecb-4f23-8378-a8fc3e3ecf19

